### PR TITLE
fix: handle repository uri containing subgroups

### DIFF
--- a/model_test.go
+++ b/model_test.go
@@ -1,0 +1,42 @@
+package resource
+
+import "testing"
+
+func TestSource_GetProjectPath_WithNamespace(t *testing.T) {
+	source := Source{
+		URI: "https://git.example.com/namespace/project.git",
+	}
+
+	actual := source.GetProjectPath()
+	expected := "namespace/project"
+
+	if actual != expected {
+		t.Errorf("Project path %s expected to be %s", actual, expected)
+	}
+}
+
+func TestSource_GetProjectPath_WithSubgroup(t *testing.T) {
+	source := Source{
+		URI: "https://git.example.com/group/subgroup1/subgroup2/project.git",
+	}
+
+	actual := source.GetProjectPath()
+	expected := "group/subgroup1/subgroup2/project"
+
+	if actual != expected {
+		t.Errorf("Project path %s expected to be %s", actual, expected)
+	}
+}
+
+func TestSource_GetProjectPath_WithoutNamespace(t *testing.T) {
+	source := Source{
+		URI: "https://git.example.com/project.git",
+	}
+
+	actual := source.GetProjectPath()
+	expected := "project"
+
+	if actual != expected {
+		t.Errorf("Project path %s expected to be %s", actual, expected)
+	}
+}

--- a/models.go
+++ b/models.go
@@ -38,8 +38,8 @@ func (source *Source) GetBaseURL() string {
 
 // GetProjectPath extracts project path from URI (repository URL).
 func (source *Source) GetProjectPath() string {
-	r, _ := regexp.Compile("([^/]+/[^/]+)\\.git/?$")
-	return r.FindStringSubmatch(source.URI)[1]
+	r, _ := regexp.Compile("(https?|ssh)://([^/]*)/(.*)\\.git$")
+	return r.FindStringSubmatch(source.URI)[3]
 }
 
 // GetCloneURL add the private token in the URI


### PR DESCRIPTION
closes #1