### PR TITLE
fix: update commit status on merge error

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"crypto/tls"
+	"github.com/xanzy/go-gitlab"
+	"github.com/samcontesse/gitlab-merge-request-resource"
 )
 
 func Fatal(doing string, err error) {
@@ -20,3 +22,20 @@ func GetDefaultClient(insecure bool) *http.Client {
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: insecure}
 	return http.DefaultClient
 }
+
+func UpdateCommitStatus(mr *gitlab.MergeRequest, source resource.Source, state gitlab.BuildStateValue) {
+	api := gitlab.NewClient(GetDefaultClient(source.Insecure), source.PrivateToken)
+	api.SetBaseURL(source.GetBaseURL())
+
+	target := source.GetTargetURL()
+	name := resource.GetPipelineName()
+
+	options := gitlab.SetCommitStatusOptions{
+		Name:      &name,
+		TargetURL: &target,
+		State:     state,
+	}
+
+	api.Commits.SetCommitStatus(mr.ProjectID, mr.SHA, &options)
+}
+

--- a/out/cmd/main.go
+++ b/out/cmd/main.go
@@ -38,20 +38,8 @@ func main() {
 	var mr gitlab.MergeRequest
 	json.Unmarshal(raw, &mr)
 
-	api := gitlab.NewClient(common.GetDefaultClient(request.Source.Insecure), request.Source.PrivateToken)
-	api.SetBaseURL(request.Source.GetBaseURL())
-
 	state := gitlab.BuildState(gitlab.BuildStateValue(request.Params.Status))
-	target := request.Source.GetTargetURL()
-	name := resource.GetPipelineName()
-
-	options := gitlab.SetCommitStatusOptions{
-		Name:      &name,
-		TargetURL: &target,
-		State:     *state,
-	}
-
-	api.Commits.SetCommitStatus(mr.ProjectID, mr.SHA, &options)
+	common.UpdateCommitStatus(&mr, request.Source, *state)
 
 	response := out.Response{Version: resource.Version{
 		ID:        mr.IID,


### PR DESCRIPTION
also mark it as `pending` as soon as the `get` is triggered and `failed`
when other errors occur.

closes #5