### PR TITLE
fix: emit new version if trigger ci is found in mr comments

### DIFF
--- a/check/cmd/main.go
+++ b/check/cmd/main.go
@@ -46,7 +46,7 @@ func main() {
 		}
 
 		if !request.Source.SkipTriggerComment {
-			notes, _, _ := api.Notes.ListMergeRequestNotes(mr.ProjectID, mr.ID, &gitlab.ListMergeRequestNotesOptions{})
+			notes, _, _ := api.Notes.ListMergeRequestNotes(mr.ProjectID, mr.IID, &gitlab.ListMergeRequestNotesOptions{})
 			updatedAt = getMostRecentUpdateTime(notes, updatedAt)
 		}
 


### PR DESCRIPTION
This issue has been introduced with the latest GitLab go library update.

ID was changed to IID.

Closes #9