### PR TITLE
support params: paths, ignore_paths, like git

### DIFF
--- a/check/cmd/main.go
+++ b/check/cmd/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"strings"
 	"time"
+	"regexp"
+	"fmt"
 )
 
 func main() {
@@ -35,6 +37,9 @@ func main() {
 	var versions []resource.Version
 	versions = make([]resource.Version, 0)
 
+	paths := fmt.Sprintf(`^(%v)\/.*`, strings.Join(request.Source.Paths, "|"))
+	ignorePaths := fmt.Sprintf(`^(%v)\/.*`, strings.Join(request.Source.IgnorePaths, "|"))
+	
 	for _, mr := range requests {
 
 		commit, _, err := api.Commits.GetCommit(mr.ProjectID, mr.SHA)
@@ -65,6 +70,14 @@ func main() {
 			continue
 		}
 
+		if len(request.Source.Paths) > 0 && !checkIncludePaths(api, paths, mr.ProjectID, mr.IID) {			
+			continue
+		}
+
+		if len(request.Source.IgnorePaths) > 0 && checkIncludePaths(api, ignorePaths, mr.ProjectID, mr.IID) {
+			continue
+		}
+
 		target := request.Source.GetTargetURL()
 		name := resource.GetPipelineName()
 
@@ -81,8 +94,32 @@ func main() {
 	}
 
 	json.NewEncoder(os.Stdout).Encode(versions)
-
 }
+
+
+func checkIncludePaths(api *gitlab.Client, paths string, projectid int, mriid int) bool {
+
+	versions, _, err := api.MergeRequests.GetMergeRequestDiffVersions(projectid, mriid, nil)
+	if err != nil {
+		common.Fatal("retrieving merge request diff versions", err)
+	}
+	
+	diff, _, err := api.MergeRequests.GetSingleMergeRequestDiffVersion(projectid, mriid, versions[0].ID)	
+	if err != nil {
+		common.Fatal("retrieving merge request diff", err)
+	}
+
+	for _, d := range diff.Diffs {
+		if match, _ := regexp.MatchString(paths, d.OldPath); match {
+			return true
+		}
+		if match, _ := regexp.MatchString(paths, d.NewPath); match {
+			return true
+		}
+	}
+	return false
+}
+
 
 func getMostRecentUpdateTime(notes []*gitlab.Note, updatedAt *time.Time) *time.Time {
 	for _, note := range notes {

--- a/models.go
+++ b/models.go
@@ -16,6 +16,9 @@ type Source struct {
 	SkipTriggerComment bool     `json:"skip_trigger_comment,omitempty"`
 	ConcourseUrl       string   `json:"concourse_url,omitempty"`
 	Labels             []string `json:"labels,omitempty"`
+
+	Paths			   []string	`json:"paths,omitempty"`
+	IgnorePaths		   []string	`json:"ignore_paths,omitempty"`
 }
 
 type Version struct {


### PR DESCRIPTION
https://github.com/samcontesse/gitlab-merge-request-resource/issues/16

sample: 

```yaml
resources:
- name: repo-mr
  type: merge-request
  source:
    uri: https://gitlab.eng.company.com/yangye/testing.git
    private_token:
    paths: ["testing/subproject2"]
    # ignore_paths: ["testing/subproject1"]

```