### PR TITLE
Order MR in check by the oldest to new ones

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2-stretch AS builder
+FROM golang:1.13.4-stretch AS builder
 
 WORKDIR /go/src/github.com/samcontesse/gitlab-merge-request-resource/
 

--- a/check/cmd/main.go
+++ b/check/cmd/main.go
@@ -26,7 +26,6 @@ func main() {
 		State:   gitlab.String("opened"),
 		OrderBy: gitlab.String("updated_at"),
 		Labels:  request.Source.Labels,
-		TargetBranch: gitlab.String(request.Source.TargetBranch)
 	}
 	requests, _, err := api.MergeRequests.ListProjectMergeRequests(request.Source.GetProjectPath(), options)
 
@@ -81,8 +80,7 @@ func main() {
 		versions = append(versions, resource.Version{ID: mr.IID, UpdatedAt: updatedAt})
 
 	}
-
-	json.NewEncoder(os.Stdout).Encode(versions)
+	json.NewEncoder(os.Stdout).Encode(reverseOrderVersions(versions))
 
 }
 
@@ -93,4 +91,14 @@ func getMostRecentUpdateTime(notes []*gitlab.Note, updatedAt *time.Time) *time.T
 		}
 	}
 	return updatedAt
+}
+
+func reverseOrderVersions(versions []resource.Version) []resource.Version {
+	newVersions := make([]resource.Version, len(versions))
+	p := 0
+	for i := len(versions) - 1; i >= 0; i-- {
+		newVersions[p] = versions[i]
+		p++
+	}
+	return newVersions
 }

--- a/go.mod
+++ b/go.mod
@@ -8,3 +8,5 @@ require (
 	github.com/xanzy/go-gitlab v0.8.1
 	golang.org/x/sys v0.0.0-20181221143128-b4a75ba826a6 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
When recreating the pipeline currently the order is from to the latest MR to the oldest, this make concourse choose the latest MR and use date time from the latest MR.

Doing that, older MR will never be used by concourse because their update time is before the latest.

For fixing this simply invert the order fix this behaviour as all MR will be given to concourse. 