### PR TITLE
add support for build_label to out

### DIFF
--- a/out/cmd/main.go
+++ b/out/cmd/main.go
@@ -48,7 +48,14 @@ func main() {
 		message = message + fmt.Sprintf("Set Status: %s \n", request.Params.Status)
 		state := gitlab.BuildState(gitlab.BuildStateValue(request.Params.Status))
 		target := request.Source.GetTargetURL()
-		name := resource.GetPipelineName()
+
+		var name string
+		if request.Params.BuildLabel != "" {
+			name = request.Params.BuildLabel
+		} else {
+			name = resource.GetPipelineName()
+		}
+
 		options := gitlab.SetCommitStatusOptions{
 			Name:      &name,
 			TargetURL: &target,

--- a/out/models.go
+++ b/out/models.go
@@ -23,6 +23,7 @@ type Params struct {
 	Status     string   `json:"status"`
 	Labels     []string `json:"labels"`
 	Comment    Comment  `json:"comment"`
+	BuildLabel string   `json:"build_label"`
 }
 
 type Comment struct {


### PR DESCRIPTION
Awesome gitlab resource :slightly_smiling_face: I've been wanting to implement something like this for over a year but never found the time and then you did it with my favourite programming language, so I'm not stuck with https://github.com/swisscom/gitlab-merge-request-resource any more. But one feature I missed from there was the `build_label` property so I could run a pipeline which set's a status on gitlab for each job in concourse.
![image](https://user-images.githubusercontent.com/20282950/87132894-d012d700-c296-11ea-9393-d95d3f11fb30.png)
