### PR TITLE
add: goreleaser and it's GitHub workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,69 @@
+name: goreleaser
+
+on:
+  push:
+    # not not consider simplec commit
+    branches:
+      - '!*'
+    # consider only release and pre-release tags
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: set up go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - name: cache go modules
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: tests modules
+        run: |
+          go mod vendor
+          if [ ! -z "$(git status --porcelain)" ]; then
+            echo "::error::vendor directory if not synched with go.mod, please run go mod vendor"
+            exit 1
+          fi
+
+          go mod tidy
+          if [ ! -z "$(git status --porcelain)" ]; then
+            echo "::error::modules are not tidy, please run go mod tidy"
+            exit 1
+          fi
+
+      - name: Docker Login
+        uses: docker/login-action@v1
+        if: success() && startsWith(github.ref, 'refs/tags/v')
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        if: success() && startsWith(github.ref, 'refs/tags/v')
+        with:
+          version: latest
+          args: release --rm-dist -p 1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_TARGET: ${{ secrets.DOCKER_TARGET }}
+          USER: github-actions

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 assets/
+/dist
 samples/
 vendor/
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,69 @@
+---
+project_name: gitlab-merge-request-resource
+
+before:
+  hooks:
+  - go mod tidy
+
+builds:
+  - &build
+    id: check
+    main: ./check/cmd/main.go
+    binary: 'assets_{{ .Os }}_{{ .Arch }}/check'
+    no_unique_dist_dir: true
+    env: [ 'CGO_ENABLED=0' ]
+    goos: [linux]
+    goarch: [amd64]
+  - <<: *build
+    id: in
+    main: ./in/cmd/main.go
+    binary: 'assets_{{ .Os }}_{{ .Arch }}/in'
+  - <<: *build
+    id: out
+    main: ./out/cmd/main.go
+    binary: 'assets_{{ .Os }}_{{ .Arch }}/out'
+
+archives:
+  - id: archives
+    builds: [check, in, out]
+    format: "tar.gz"
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+    wrap_in_directory: true
+    files:
+      - README*
+      - assets/*
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+    - 'docs'
+    - '\.md'
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+dockers:
+  - goos: linux
+    goarch: amd64
+    image_templates:
+      - "{{ .Env.DOCKER_TARGET }}:latest"
+      - "{{ .Env.DOCKER_TARGET }}:v{{ .Major }}"
+      - "{{ .Env.DOCKER_TARGET }}:v{{ .Major }}.{{ .Minor }}"
+      - "{{ .Env.DOCKER_TARGET }}:v{{ .Version }}"
+    build_flag_templates:
+      # https://github.com/opencontainers/image-spec/
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.source={{ .GitURL }}"
+      - "--platform=linux/amd64"
+
+release:
+  prerelease: auto
+  name_template: '{{.Tag}}'
+
+...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,4 @@
-FROM golang:1.13-stretch AS builder
-
-WORKDIR /go/src/github.com/samcontesse/gitlab-merge-request-resource/
-
-COPY . .
-
-RUN GOARCH=amd64 GOOS=linux && \
-    go build -o assets/in in/cmd/main.go && \
-    go build -o assets/out out/cmd/main.go && \
-    go build -o assets/check check/cmd/main.go
-
 FROM concourse/buildroot:git
-COPY --from=builder /go/src/github.com/samcontesse/gitlab-merge-request-resource/assets/* /opt/resource/
+COPY check /opt/resource/
+COPY in /opt/resource/
+COPY out /opt/resource/


### PR DESCRIPTION
Following #36; we would like to suggest the use of [GoReleaser](https://goreleaser.com/) to automate the provision of the binaries.
I would also like to suggest it's use to automatically publish the OCI artifact on DockerHub: https://goreleaser.com/customization/docker/.

This configuration assume that you added to your (GitHub) project Settings > Secrets the (required by [goreleaser v0.140.1](https://github.com/till/goreleaser/blob/v0.140.1/scripts/entrypoint.sh) or https://github.com/goreleaser/goreleaser-action/issues/261) variables :
- **DOCKER_USERNAME**: your Docker Hub username (ie: `samcontesse`)
- **DOCKER_PASSWORD**: the Docker Hub token *or* password related to the target (ie: `ff38b6a6-611b-4537-8d72-84367fb39ea7`)
- **DOCKER_TARGET**: the Docker Hub target (ie: `samcontesse/gitlab-merge-request-resource`)
- **DOCKER_REGISTRY** (optional): to change the default registry

Edit: sorry for the sudden draft on this PR, it was not ready when I started it ('-_-)