### PR TITLE
Option to revert MR sorting order

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ resources:
 * `pipeline_name`(string): When set, this url will be used to override `BUILD_PIPELINE_NAME` during commit status updates.  
 * `labels`(string[]): Filter merge requests by label`[]`
 * `target_branch`(string): Filter merge requests by target_branch. Default is empty string.
+* `sort` (string): Merge requests sorting order, either `asc` (default) or `desc` to reverse.
 
 ## Behavior
 

--- a/check/cmd/main.go
+++ b/check/cmd/main.go
@@ -24,10 +24,15 @@ func main() {
 
 	labels := gitlab.Labels(request.Source.Labels)
 
+	// https://docs.gitlab.com/ee/api/pipelines.html#list-project-pipelines
+	sort, err := request.Source.GetSort()
+	if err != nil {
+		common.Fatal("failed to get sort order", err)
+	}
 	options := &gitlab.ListProjectMergeRequestsOptions{
 		State:        gitlab.String("opened"),
 		OrderBy:      gitlab.String("updated_at"),
-		Sort:         gitlab.String("asc"),
+		Sort:         gitlab.String(sort),
 		Labels:       &labels,
 		TargetBranch: gitlab.String(request.Source.TargetBranch),
 	}

--- a/model_test.go
+++ b/model_test.go
@@ -40,3 +40,33 @@ func TestSource_GetProjectPath_WithoutNamespace(t *testing.T) {
 		t.Errorf("Project path %s expected to be %s", actual, expected)
 	}
 }
+
+func TestSource_GetSort(t *testing.T) {
+	tests := []struct {
+		sort string
+		want string
+		wantErr bool
+	}{
+		{"asc", "asc", false},
+		{"desc", "desc", false},
+		{"", "asc", false},
+		{"invalid", "", true},
+		{"AsC", "asc", false},
+		{"DESC", "desc", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.sort, func(t *testing.T) {
+			source := Source{
+				URI: "https://git.example.com/project.git",
+				Sort: tt.sort,
+			}
+			got, err := source.GetSort()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetSort() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("GetSort() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/models.go
+++ b/models.go
@@ -1,9 +1,11 @@
 package resource
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -18,6 +20,7 @@ type Source struct {
 	PipelineName       string   `json:"pipeline_name,omitempty"`
 	Labels             []string `json:"labels,omitempty"`
 	TargetBranch       string   `json:"target_branch,omitempty"`
+	Sort               string   `json:"sort,omitempty"`
 }
 
 type Version struct {
@@ -69,4 +72,15 @@ func (source *Source) GetPipelineName() string {
 		return os.Getenv("BUILD_PIPELINE_NAME")
 	}
 
+}
+
+func (source *Source) GetSort() (string, error) {
+	order := strings.ToLower(source.Sort)
+	switch order {
+	case "":
+		return "asc", nil
+	case "asc", "desc":
+		return order, nil
+	}
+	return "", fmt.Errorf("invalid value for sort: %v", source.Sort)
 }


### PR DESCRIPTION
In our case we want to be able to change the sorting orders of the merge requests to get the most recent first.