### PR TITLE
upgrade git in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM concourse/buildroot:git
+ARG ALPINE_VERSION=3.16
+FROM alpine:$ALPINE_VERSION
+RUN apk add --update-cache git openssh-client \
+ && git --version
 COPY check /opt/resource/
 COPY in /opt/resource/
 COPY out /opt/resource/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A concourse resource to check for new merge requests on GitLab and update the merge request status.
 
+The provided Docker image is Alpine-based.
+
 ## Source Configuration
 
 ```yaml


### PR DESCRIPTION
This change the base image from the deprecated `concourse/buildroot:git` to an Alpine with `git` and `openssh-client`; relates to #76