### PR TITLE
Skip merge request that reference no commit

### DIFF
--- a/pkg/check/command.go
+++ b/pkg/check/command.go
@@ -43,16 +43,17 @@ func (command *Command) Run(request Request) (Response, error) {
 	versions := make([]pkg.Version, 0)
 
 	for _, mr := range requests {
+		if mr.SHA == nil {
+			// 1. skip orphan MRs
+			continue
+		}
 
 		commit, _, err := command.client.Commits.GetCommit(mr.ProjectID, mr.SHA)
 		if err != nil {
 			return Response{}, err
-		}
-		updatedAt := commit.CommittedDate
+		}		
 
-		if err != nil {
-			continue
-		}
+		updatedAt := commit.CommittedDate
 
 		if strings.Contains(commit.Title, "[skip ci]") || strings.Contains(commit.Message, "[skip ci]") {
 			continue


### PR DESCRIPTION
This PR fixes a corner case where the check resource ends in error `error running command: SHA must be a non-empty string` when the target projet has a merge-request that references no commit (`sha == null` in gitlab api).

It also remove a dead condition, `err` is tested twice for nil in a row.