### PR TITLE
Move submodule update below the MR fetch

### DIFF
--- a/pkg/in/command.go
+++ b/pkg/in/command.go
@@ -61,18 +61,18 @@ func (command *Command) Run(destination string, request Request) (Response, erro
 
 	os.Chdir(destination)
 
-	if request.Source.Recursive {
-		err = command.runner.Run("submodule", "update", "--init", "--recursive")
-		if err != nil {
-			return Response{}, err
-		}
-	}
-
 	command.runner.Run("remote", "add", "source", source.String())
 	command.runner.Run("remote", "update")
 	command.runner.Run("merge", "--no-ff", "--no-commit", mr.SHA)
 	if err != nil {
 		return Response{}, err
+	}
+
+	if request.Source.Recursive {
+		err = command.runner.Run("submodule", "update", "--init", "--recursive")
+		if err != nil {
+			return Response{}, err
+		}
 	}
 
 	notes, _ := json.Marshal(mr)


### PR DESCRIPTION
Hey please don't hate me, but I thought this was part of #89 

In short, when the gitlab MR contains a submodule ref or URL change, the checked out code wil not match the MR..